### PR TITLE
refactor attribute conversion to make it more approachable for newcomers

### DIFF
--- a/dsl/attribute-conversion.js
+++ b/dsl/attribute-conversion.js
@@ -1,4 +1,6 @@
 /* jshint node:true */
+"use strict"
+
 /**
  * An HTMLBars AST transformation that converts
  * flexi attributes into CSS classes

--- a/dsl/attribute-conversion.js
+++ b/dsl/attribute-conversion.js
@@ -3,13 +3,13 @@
  * An HTMLBars AST transformation that converts
  * flexi attributes into CSS classes
  **/
-var DSL = require('./dsl-defaults');
-var MIN_COLUMN_COUNT = 1;
-var assign = require('object-assign');
-var chalk = require('chalk');
-var debug = require('debug')('flexi');
-var getAttribute = require("./helpers/get-attribute");
-var removeAttributeFromNode = require("./helpers/remove-attribute");
+let DSL = require('./dsl-defaults');
+let MIN_COLUMN_COUNT = 1;
+let assign = require('object-assign');
+let chalk = require('chalk');
+let debug = require('debug')('flexi');
+let getAttribute = require("./helpers/get-attribute");
+let removeAttributeFromNode = require("./helpers/remove-attribute");
 
 /**
  * htmlbars-ast-plugin that gets registered from index.js.
@@ -17,237 +17,233 @@ var removeAttributeFromNode = require("./helpers/remove-attribute");
  * AttributeConversionSupport.transform() gets called automatically at build time,
  * converting flexi attributes on flexi elements to CSS classes.
  **/
-function AttributeConversionSupport() {
-  // NOTE: this.flexiConfig is added to the prototype from index.js
+class AttributeConversionSupport {
+  constructor() {
+    // NOTE: this.flexiConfig is added to the prototype from index.js
+    this.dsl = {};
+    assign(this.dsl, DSL);
 
-  this.dsl = {};
-  assign(this.dsl, DSL);
+    this.dsl.generateGridClass = this.flexiConfig.generateGridClass || this.dsl.generateGridClass;
+    this.dsl.generateResponderClass = this.flexiConfig.generateResponderClass || this.dsl.generateResponderClass;
+    this.dsl.generateAttributeClass = this.flexiConfig.generateAttributeClass || this.dsl.generateAttributeClass;
+    this.dsl.generateOffsetClass = this.flexiConfig.generateOffsetClass || this.dsl.generateOffsetClass;
 
-  this.dsl.generateGridClass = this.flexiConfig.generateGridClass || this.dsl.generateGridClass;
-  this.dsl.generateResponderClass = this.flexiConfig.generateResponderClass || this.dsl.generateResponderClass;
-  this.dsl.generateAttributeClass = this.flexiConfig.generateAttributeClass || this.dsl.generateAttributeClass;
-  this.dsl.generateOffsetClass = this.flexiConfig.generateOffsetClass || this.dsl.generateOffsetClass;
-
-  this.dsl.elements = uniqueMergeArrays(this.dsl.elements, this.flexiConfig.elements || []);
-  this.dsl.responders = uniqueMergeArrays(this.dsl.responders, this.flexiConfig.responders || []);
-  this.dsl.attributes = uniqueMergeArrays(this.dsl.attributes, this.flexiConfig.attributes || []);
-  this.dsl.breakpoints = this.flexiConfig.breakpoints;
-  this.dsl.transformAll = this.flexiConfig.transformAllElementLayoutAttributes || false;
-}
-
-function uniqueMergeArrays() {
-  var keys = [];
-
-  for (var i = 0; i < arguments.length; i++) {
-    for (var j = 0; j < arguments[i].length; j++) {
-      if (keys.indexOf(arguments[i][j]) === -1) {
-        keys.push(arguments[i][j]);
-      }
-    }
+    this.dsl.elements = this._uniqueMergeArrays(this.dsl.elements, this.flexiConfig.elements || []);
+    this.dsl.responders = this._uniqueMergeArrays(this.dsl.responders, this.flexiConfig.responders || []);
+    this.dsl.attributes = this._uniqueMergeArrays(this.dsl.attributes, this.flexiConfig.attributes || []);
+    this.dsl.breakpoints = this.flexiConfig.breakpoints;
+    this.dsl.transformAll = this.flexiConfig.transformAllElementLayoutAttributes || false;
   }
 
-  return keys;
-}
+  _uniqueMergeArrays() {
+    let keys = [];
 
-var proto = AttributeConversionSupport.prototype;
+    for (let i = 0; i < arguments.length; i++) {
+      for (let j = 0; j < arguments[i].length; j++) {
+        if (keys.indexOf(arguments[i][j]) === -1) {
+          keys.push(arguments[i][j]);
+        }
+      }
+    }
 
-/**
- * Walk through every node in the AST, transforming attributes to CSS
- * classes by altering the "class" AttrNode of relevant elements.
- * To see how the AST looks in Glimmer: http://astexplorer.net/
- **/
-proto.transform = function AttributeConversionSupport_transform(ast) {
-  var _plugin = this;
-  var _dsl = _plugin.dsl;
+    return keys;
+  }
 
   /**
-   * // will be used in the future for custom CSS classes
-   * var _seen = {
-   *   elements: {},
-   *   responders: {},
-   *   breakpoints: {},
-   *   attributes: {}
-   * };
+   * Walk through every node in the AST, transforming attributes to CSS
+   * classes by altering the "class" AttrNode of relevant elements.
+   * To see how the AST looks in Glimmer: http://astexplorer.net/
    **/
+  transform(ast) {
+    /**
+     * // will be used in the future for custom CSS classes
+     * let _seen = {
+     *   elements: {},
+     *   responders: {},
+     *   breakpoints: {},
+     *   attributes: {}
+     * };
+     **/
 
-  var _walker = new _plugin.syntax.Walker();
+    let _walker = new this.syntax.Walker();
 
-  _walker.visit(ast, function (node) {
-    if (!_plugin.isElementWeConvertAttributesFor(node)) {
-      return;
-    }
-
-    debug(chalk.cyan("\tConverting attributes for node: ") + chalk.yellow(node.tag));
-
-    // Will be used in the future for custom CSS classes
-    // _seen.elements[node.tag] = true;
-
-    // Maintain a list of all class names that will be applied to the element,
-    // starting with any classes the element already has
-    var classNames = [];
-    var classAttr = getAttribute(node, "class");
-
-    if (classAttr && classAttr.value.chars) {
-      debug(chalk.grey("\t\tStarting with original class string: ") + chalk.white(classAttr.value.chars));
-
-      classNames.push(classAttr.value.chars);
-    }
-
-    // Convert attributes that aren't in a breakpoint attribute
-    _dsl.attributes.forEach(function(attr) {
-      var className = _plugin.convertAttribute(node, attr);
-
-      if (className) {
-        classNames.push(className);
-      }
-    });
-
-    // Convert breakpoint and responder values
-    _dsl.breakpoints.forEach(function(breakpoint) {
-      var breakpoint_attribute = getAttribute(node, breakpoint.prefix);
-
-      if (!breakpoint_attribute) {
-        // This element doesn't have an attribute for this breakpoint,
-        // continue to the next breakpoint
+    _walker.visit(ast, (node) => {
+      if (!this._isElementWeConvertAttributesFor(node)) {
         return;
       }
 
-      breakpoint_attribute.value.chars.split(" ").forEach(function(value) {
-        // Convert column number values
-        var columns = parseInt(value, 10);
-        if (!isNaN(columns)) {
-          classNames.push(_plugin.convertGridColumns(breakpoint, columns));
+      debug(chalk.cyan("\tConverting attributes for node: ") + chalk.yellow(node.tag));
 
-          return;
+      // Will be used in the future for custom CSS classes
+      // _seen.elements[node.tag] = true;
+
+      // Maintain a list of all class names that will be applied to the element,
+      // starting with any classes the element already has
+      let classNames = [];
+      let classAttr = getAttribute(node, "class");
+
+      if (classAttr && classAttr.value.chars) {
+        debug(chalk.grey("\t\tStarting with original class string: ") + chalk.white(classAttr.value.chars));
+
+        classNames.push(classAttr.value.chars);
+      }
+
+      // Convert attributes that aren't in a breakpoint attribute
+      this.dsl.attributes.forEach((attr) => {
+        let className = this._convertAttribute(node, attr);
+
+        if (className) {
+          classNames.push(className);
         }
-
-        // Convert responder values
-        if (_dsl.responders.indexOf(value) !== -1) {
-          classNames.push(_plugin.convertResponderValue(breakpoint, value));
-
-          return;
-        }
-
-        // Convert offset values
-        if (value.indexOf('offset-') === 0) {
-          classNames.push(_plugin.convertOffsetColumns(breakpoint, value));
-
-          return;
-        }
-
-        throw new Error("Flexi#attribute-conversion:: '" + value + "' is not a valid value for a breakpoint.");
       });
 
-      // Clean up the element by removing our custom attribute
-      removeAttributeFromNode(node, breakpoint_attribute);
+      // Convert breakpoint and responder values
+      this.dsl.breakpoints.forEach((breakpoint) => {
+        let breakpoint_attribute = getAttribute(node, breakpoint.prefix);
+
+        if (!breakpoint_attribute) {
+          // This element doesn't have an attribute for this breakpoint,
+          // continue to the next breakpoint
+          return;
+        }
+
+        breakpoint_attribute.value.chars.split(" ").forEach((value) => {
+          // Convert column number values
+          let columns = parseInt(value, 10);
+          if (!isNaN(columns)) {
+            classNames.push(this._convertGridColumns(breakpoint, columns));
+
+            return;
+          }
+
+          // Convert responder values
+          if (this.dsl.responders.indexOf(value) !== -1) {
+            classNames.push(this._convertResponderValue(breakpoint, value));
+
+            return;
+          }
+
+          // Convert offset values
+          if (value.indexOf('offset-') === 0) {
+            classNames.push(this._convertOffsetColumns(breakpoint, value));
+
+            return;
+          }
+
+          throw new Error("Flexi#attribute-conversion:: '" + value + "' is not a valid value for a breakpoint.");
+        });
+
+        // Clean up the element by removing our custom attribute
+        removeAttributeFromNode(node, breakpoint_attribute);
+      });
+
+      debug(chalk.magenta("\t\tFinal Class: ") + chalk.white(classNames.join(" ")));
+
+      if (!classNames.length) {
+        // No attributes were found on the element
+        return;
+      }
+
+      if (!classAttr) {
+        node.attributes.push({
+          type: "AttrNode",
+          name: "class",
+          value: { type: "TextNode", chars: classNames.join(" ") }
+        });
+
+        return;
+      }
+
+      // If the AttrNode for "class" contains a MustacheStatement, `{{somethingDynamic}}`,
+      // it will be a ConcatStatement node. In such a case, add a TextNode with our
+      // classes to the list of Nodes to be concatenated.
+      if (classAttr.value.type === "ConcatStatement") {
+        classAttr.value.parts.push({ type: "TextNode", chars: " " + classNames.join(" ") });
+      } else {
+        classAttr.value.chars = classNames.join(" ");
+      }
     });
 
-    debug(chalk.magenta("\t\tFinal Class: ") + chalk.white(classNames.join(" ")));
+    return ast;
+  };
 
-    if (!classNames.length) {
-      // No attributes were found on the element
-      return;
-    }
-
-    if (!classAttr) {
-      node.attributes.push({
-        type: "AttrNode",
-        name: "class",
-        value: { type: "TextNode", chars: classNames.join(" ") }
-      });
-
-      return;
-    }
-
-    // If the AttrNode for "class" contains a MustacheStatement, `{{somethingDynamic}}`,
-    // it will be a ConcatStatement node. In such a case, add a TextNode with our
-    // classes to the list of Nodes to be concatenated.
-    if (classAttr.value.type === "ConcatStatement") {
-      classAttr.value.parts.push({ type: "TextNode", chars: " " + classNames.join(" ") });
-    } else {
-      classAttr.value.chars = classNames.join(" ");
-    }
-  });
-
-  return ast;
-};
-
-proto.isElementWeConvertAttributesFor = function AttributeConversionSupport_isElementWeConvertAttributesFor(node) {
-  return node.type === "ElementNode" &&
-    (this.dsl.transformAll || this.dsl.elements.indexOf(node.tag) !== -1);
-}
-
-proto.convertAttribute = function AttributeConversionSupport_convertAttribute(node, attribute) {
-  var isComplex = typeof attribute !== 'string';
-  var name = isComplex ? attribute.name : attribute;
-  var values = isComplex ? attribute.values : [];
-  var attr = getAttribute(node, name);
-  var value;
-
-  if (attr) {
-    value =  attr.value.chars;
-
-    if (!isComplex && value) {
-      throw new Error("Flexi#attribute-conversion:: Attribute '" + attribute +
-        "' does not expect a value, given '" + value + "'.");
-    }
-
-    if (isComplex && values.indexOf(value) === -1) {
-      throw new Error("Flexi#attribute-conversion:: '" + value +
-        "' is not a valid value for " + name + ".");
-    }
-
-    var className = this.dsl.generateAttributeClass(name, value);
-
-    debug(chalk.grey("\t\tGenerated class: ") + chalk.white(className));
-
-    // Clean up the element by removing our custom attribute
-    removeAttributeFromNode(node, attr);
-
-    return className;
-  }
-}
-
-proto.convertGridColumns = function AttributeConversionSupport_convertGridColumns(breakpoint, columns) {
-  if (columns >= MIN_COLUMN_COUNT && columns <= this.flexiConfig.columns) {
-    var columnClassName = this.dsl.generateGridClass(breakpoint,
-                                                     columns,
-                                                     this.flexiConfig.columnPrefix,
-                                                     this.flexiConfig.columns);
-
-    debug(chalk.grey("\t\tGenerated column class: ") + chalk.white(columnClassName));
-
-    return columnClassName;
+  _isElementWeConvertAttributesFor(node) {
+    return node.type === "ElementNode" &&
+      (this.dsl.transformAll || this.dsl.elements.indexOf(node.tag) !== -1);
   }
 
-  throw new Error("Flexi#attribute-conversion:: '" + columns +
-    "' is not a valid column value for " + breakpoint.prefix + ".");
-}
+  _convertAttribute(node, attribute) {
+    let isComplex = typeof attribute !== 'string';
+    let name = isComplex ? attribute.name : attribute;
+    let values = isComplex ? attribute.values : [];
+    let attr = getAttribute(node, name);
+    let value;
 
-proto.convertResponderValue = function AttributeConversionSupport_convertResponderValue(breakpoint, value) {
-  var responderClassName = this.dsl.generateResponderClass(breakpoint, value);
+    if (attr) {
+      value =  attr.value.chars;
 
-  debug(chalk.grey("\t\tGenerated responsive class: ") + chalk.white(responderClassName));
+      if (!isComplex && value) {
+        throw new Error("Flexi#attribute-conversion:: Attribute '" + attribute +
+          "' does not expect a value, given '" + value + "'.");
+      }
 
-  return responderClassName;
-}
+      if (isComplex && values.indexOf(value) === -1) {
+        throw new Error("Flexi#attribute-conversion:: '" + value +
+          "' is not a valid value for " + name + ".");
+      }
 
-proto.convertOffsetColumns = function AttributeConversionSupport_convertOffsetColumns(breakpoint, value) {
-  var offset = parseInt(value.substr(7), 10);
+      let className = this.dsl.generateAttributeClass(name, value);
 
-  if (!isNan(offset) && offset >= 0 && offset < this.flexiConfig.columns) {
-    var offsetClassName = this.dsl.generateOffsetClass(breakpoint,
-                                                       offset,
+      debug(chalk.grey("\t\tGenerated class: ") + chalk.white(className));
+
+      // Clean up the element by removing our custom attribute
+      removeAttributeFromNode(node, attr);
+
+      return className;
+    }
+  }
+
+  _convertGridColumns(breakpoint, columns) {
+    if (columns >= MIN_COLUMN_COUNT && columns <= this.flexiConfig.columns) {
+      let columnClassName = this.dsl.generateGridClass(breakpoint,
+                                                       columns,
                                                        this.flexiConfig.columnPrefix,
                                                        this.flexiConfig.columns);
 
-    debug(chalk.grey("\t\Generated offset class: ") + chalk.white(offsetClassName));
+      debug(chalk.grey("\t\tGenerated column class: ") + chalk.white(columnClassName));
 
-    return offsetClassName;
+      return columnClassName;
+    }
+
+    throw new Error("Flexi#attribute-conversion:: '" + columns +
+      "' is not a valid column value for " + breakpoint.prefix + ".");
   }
 
-  throw new Error("Flexi#attribute-conversion:: '" + offset +
-    "' is not a valid column offset for " + breakpoint.prefix + ".");
+  _convertResponderValue(breakpoint, value) {
+    let responderClassName = this.dsl.generateResponderClass(breakpoint, value);
+
+    debug(chalk.grey("\t\tGenerated responsive class: ") + chalk.white(responderClassName));
+
+    return responderClassName;
+  }
+
+  _convertOffsetColumns(breakpoint, value) {
+    let offset = parseInt(value.substr(7), 10);
+
+    if (!isNan(offset) && offset >= 0 && offset < this.flexiConfig.columns) {
+      let offsetClassName = this.dsl.generateOffsetClass(breakpoint,
+                                                         offset,
+                                                         this.flexiConfig.columnPrefix,
+                                                         this.flexiConfig.columns);
+
+      debug(chalk.grey("\t\Generated offset class: ") + chalk.white(offsetClassName));
+
+      return offsetClassName;
+    }
+
+    throw new Error("Flexi#attribute-conversion:: '" + offset +
+      "' is not a valid column offset for " + breakpoint.prefix + ".");
+  }
 }
 
 module.exports = AttributeConversionSupport;

--- a/dsl/attribute-conversion.js
+++ b/dsl/attribute-conversion.js
@@ -1,15 +1,39 @@
 /* jshint node:true */
 /**
- An HTMLBars AST transformation that converts instances of
- layout elements to their corresponding layout-component
- */
-var removeAttribute = require("./helpers/remove-attribute");
-var getAttribute = require("./helpers/get-attribute");
-var MIN_COLUMN_COUNT = 1;
+ * An HTMLBars AST transformation that converts
+ * flexi attributes into CSS classes
+ **/
 var DSL = require('./dsl-defaults');
+var MIN_COLUMN_COUNT = 1;
 var assign = require('object-assign');
 var chalk = require('chalk');
 var debug = require('debug')('flexi');
+var getAttribute = require("./helpers/get-attribute");
+var removeAttributeFromNode = require("./helpers/remove-attribute");
+
+/**
+ * htmlbars-ast-plugin that gets registered from index.js.
+ *
+ * AttributeConversionSupport.transform() gets called automatically at build time,
+ * converting flexi attributes on flexi elements to CSS classes.
+ **/
+function AttributeConversionSupport() {
+  // NOTE: this.flexiConfig is added to the prototype from index.js
+
+  this.dsl = {};
+  assign(this.dsl, DSL);
+
+  this.dsl.generateGridClass = this.flexiConfig.generateGridClass || this.dsl.generateGridClass;
+  this.dsl.generateResponderClass = this.flexiConfig.generateResponderClass || this.dsl.generateResponderClass;
+  this.dsl.generateAttributeClass = this.flexiConfig.generateAttributeClass || this.dsl.generateAttributeClass;
+  this.dsl.generateOffsetClass = this.flexiConfig.generateOffsetClass || this.dsl.generateOffsetClass;
+
+  this.dsl.elements = uniqueMergeArrays(this.dsl.elements, this.flexiConfig.elements || []);
+  this.dsl.responders = uniqueMergeArrays(this.dsl.responders, this.flexiConfig.responders || []);
+  this.dsl.attributes = uniqueMergeArrays(this.dsl.attributes, this.flexiConfig.attributes || []);
+  this.dsl.breakpoints = this.flexiConfig.breakpoints;
+  this.dsl.transformAll = this.flexiConfig.transformAllElementLayoutAttributes || false;
+}
 
 function uniqueMergeArrays() {
   var keys = [];
@@ -25,11 +49,138 @@ function uniqueMergeArrays() {
   return keys;
 }
 
-function convertAttribute(node, dsl, attribute) {
+var proto = AttributeConversionSupport.prototype;
+
+/**
+ * Walk through every node in the AST, transforming attributes to CSS
+ * classes by altering the "class" AttrNode of relevant elements.
+ * To see how the AST looks in Glimmer: http://astexplorer.net/
+ **/
+proto.transform = function AttributeConversionSupport_transform(ast) {
+  var _plugin = this;
+  var _dsl = _plugin.dsl;
+
+  /**
+   * // will be used in the future for custom CSS classes
+   * var _seen = {
+   *   elements: {},
+   *   responders: {},
+   *   breakpoints: {},
+   *   attributes: {}
+   * };
+   **/
+
+  var _walker = new _plugin.syntax.Walker();
+
+  _walker.visit(ast, function (node) {
+    if (!_plugin.isElementWeConvertAttributesFor(node)) {
+      return;
+    }
+
+    debug(chalk.cyan("\tConverting attributes for node: ") + chalk.yellow(node.tag));
+
+    // Will be used in the future for custom CSS classes
+    // _seen.elements[node.tag] = true;
+
+    // Maintain a list of all class names that will be applied to the element,
+    // starting with any classes the element already has
+    var classNames = [];
+    var classAttr = getAttribute(node, "class");
+
+    if (classAttr && classAttr.value.chars) {
+      debug(chalk.grey("\t\tStarting with original class string: ") + chalk.white(classAttr.value.chars));
+
+      classNames.push(classAttr.value.chars);
+    }
+
+    // Convert attributes that aren't in a breakpoint attribute
+    _dsl.attributes.forEach(function(attr) {
+      var className = _plugin.convertAttribute(node, attr);
+
+      if (className) {
+        classNames.push(className);
+      }
+    });
+
+    // Convert breakpoint and responder values
+    _dsl.breakpoints.forEach(function(breakpoint) {
+      var breakpoint_attribute = getAttribute(node, breakpoint.prefix);
+
+      if (!breakpoint_attribute) {
+        // This element doesn't have an attribute for this breakpoint,
+        // continue to the next breakpoint
+        return;
+      }
+
+      breakpoint_attribute.value.chars.split(" ").forEach(function(value) {
+        // Convert column number values
+        var columns = parseInt(value, 10);
+        if (!isNaN(columns)) {
+          classNames.push(_plugin.convertGridColumns(breakpoint, columns));
+
+          return;
+        }
+
+        // Convert responder values
+        if (_dsl.responders.indexOf(value) !== -1) {
+          classNames.push(_plugin.convertResponderValue(breakpoint, value));
+
+          return;
+        }
+
+        // Convert offset values
+        if (value.indexOf('offset-') === 0) {
+          classNames.push(_plugin.convertOffsetColumns(breakpoint, value));
+
+          return;
+        }
+
+        throw new Error("Flexi#attribute-conversion:: '" + value + "' is not a valid value for a breakpoint.");
+      });
+
+      // Clean up the element by removing our custom attribute
+      removeAttributeFromNode(node, breakpoint_attribute);
+    });
+
+    debug(chalk.magenta("\t\tFinal Class: ") + chalk.white(classNames.join(" ")));
+
+    if (!classNames.length) {
+      // No attributes were found on the element
+      return;
+    }
+
+    if (!classAttr) {
+      node.attributes.push({
+        type: "AttrNode",
+        name: "class",
+        value: { type: "TextNode", chars: classNames.join(" ") }
+      });
+
+      return;
+    }
+
+    // If the AttrNode for "class" contains a MustacheStatement, `{{somethingDynamic}}`,
+    // it will be a ConcatStatement node. In such a case, add a TextNode with our
+    // classes to the list of Nodes to be concatenated.
+    if (classAttr.value.type === "ConcatStatement") {
+      classAttr.value.parts.push({ type: "TextNode", chars: " " + classNames.join(" ") });
+    } else {
+      classAttr.value.chars = classNames.join(" ");
+    }
+  });
+
+  return ast;
+};
+
+proto.isElementWeConvertAttributesFor = function AttributeConversionSupport_isElementWeConvertAttributesFor(node) {
+  return node.type === "ElementNode" &&
+    (this.dsl.transformAll || this.dsl.elements.indexOf(node.tag) !== -1);
+}
+
+proto.convertAttribute = function AttributeConversionSupport_convertAttribute(node, attribute) {
   var isComplex = typeof attribute !== 'string';
   var name = isComplex ? attribute.name : attribute;
   var values = isComplex ? attribute.values : [];
-  // debug('converting '  + (isComplex ? 'complex ' : '') + (typeof attribute) + ' attribute ' + name);
   var attr = getAttribute(node, name);
   var value;
 
@@ -46,179 +197,57 @@ function convertAttribute(node, dsl, attribute) {
         "' is not a valid value for " + name + ".");
     }
 
-    var className = dsl.generateAttributeClass(name, value);
-    debug(chalk.grey("\t\tPushing class: ") + chalk.white(className));
+    var className = this.dsl.generateAttributeClass(name, value);
 
-    removeAttribute(node, attr);
+    debug(chalk.grey("\t\tGenerated class: ") + chalk.white(className));
+
+    // Clean up the element by removing our custom attribute
+    removeAttributeFromNode(node, attr);
 
     return className;
   }
 }
 
+proto.convertGridColumns = function AttributeConversionSupport_convertGridColumns(breakpoint, columns) {
+  if (columns >= MIN_COLUMN_COUNT && columns <= this.flexiConfig.columns) {
+    var columnClassName = this.dsl.generateGridClass(breakpoint,
+                                                     columns,
+                                                     this.flexiConfig.columnPrefix,
+                                                     this.flexiConfig.columns);
 
+    debug(chalk.grey("\t\tGenerated column class: ") + chalk.white(columnClassName));
 
-function AttributeConversionSupport() {
-  this.syntax = null;
+    return columnClassName;
+  }
 
-  /*
-    DSL Configuration Support
-   */
-  this.dsl = {};
-  assign(this.dsl, DSL);
-
-  this.dsl.generateGridClass = this.flexiConfig.generateGridClass || this.dsl.generateGridClass;
-  this.dsl.generateResponderClass = this.flexiConfig.generateResponderClass || this.dsl.generateResponderClass;
-  this.dsl.generateAttributeClass = this.flexiConfig.generateAttributeClass || this.dsl.generateAttributeClass;
-  this.dsl.generateOffsetClass = this.flexiConfig.generateOffsetClass || this.dsl.generateOffsetClass;
-
-  this.dsl.elements = uniqueMergeArrays(this.dsl.elements, this.flexiConfig.elements || []);
-  this.dsl.responders = uniqueMergeArrays(this.dsl.responders, this.flexiConfig.responders || []);
-  this.dsl.attributes = uniqueMergeArrays(this.dsl.attributes, this.flexiConfig.attributes || []);
-  this.dsl.breakpoints = this.flexiConfig.breakpoints;
-  this.dsl.transformAll = this.flexiConfig.transformAllElementLayoutAttributes || false;
-
+  throw new Error("Flexi#attribute-conversion:: '" + columns +
+    "' is not a valid column value for " + breakpoint.prefix + ".");
 }
 
-var proto = AttributeConversionSupport.prototype;
+proto.convertResponderValue = function AttributeConversionSupport_convertResponderValue(breakpoint, value) {
+  var responderClassName = this.dsl.generateResponderClass(breakpoint, value);
 
-proto.transform = function AttributeConversionSupport_transform(ast) {
-  var _plugin = this;
-  var _dsl = this.dsl;
-  var walker = new _plugin.syntax.Walker();
-  var _seen = {
-    elements: {},
-    responders: {},
-    breakpoints: {},
-    attributes: {}
-  };
+  debug(chalk.grey("\t\tGenerated responsive class: ") + chalk.white(responderClassName));
 
-  walker.visit(ast, function (node) {
-    if (_plugin.validate(node)) {
-      debug(chalk.cyan("\tConverting Attributes for node: ") + chalk.yellow(node.tag));
-      _seen.elements[node.tag] = true;
+  return responderClassName;
+}
 
-      var classNames = [];
-      var classAttr = getAttribute(node, "class");
+proto.convertOffsetColumns = function AttributeConversionSupport_convertOffsetColumns(breakpoint, value) {
+  var offset = parseInt(value.substr(7), 10);
 
-      if (classAttr && classAttr.value.chars) {
-        debug(chalk.grey("\t\tPushing Original Class String: ") + chalk.white(classAttr.value.chars));
+  if (!isNan(offset) && offset >= 0 && offset < this.flexiConfig.columns) {
+    var offsetClassName = this.dsl.generateOffsetClass(breakpoint,
+                                                       offset,
+                                                       this.flexiConfig.columnPrefix,
+                                                       this.flexiConfig.columns);
 
-        classNames.push(classAttr.value.chars);
-      }
+    debug(chalk.grey("\t\Generated offset class: ") + chalk.white(offsetClassName));
 
-      /*
-        Convert Attributes
-      */
-      _dsl.attributes.forEach(function(attr) {
-        var className = convertAttribute(node, _dsl, attr);
+    return offsetClassName;
+  }
 
-        if (className) {
-          classNames.push(className);
-        }
-      });
-
-      /*
-       Convert Breakpoints & Responders
-       */
-      _dsl.breakpoints.forEach(function(breakpoint) {
-        var attr = getAttribute(node, breakpoint.prefix);
-
-        if (attr) {
-          var value = attr.value.chars.split(" ");
-
-          value.forEach(function(v) {
-            var className;
-
-            /*
-             Convert Grid Columns
-             */
-            var int = parseInt(v, 10);
-            if (!isNaN(int)) {
-              if (int >= MIN_COLUMN_COUNT && int <= _plugin.flexiConfig.columns) {
-                className = _dsl.generateGridClass(breakpoint, int, _plugin.flexiConfig.columnPrefix, _plugin.flexiConfig.columns);
-                debug(chalk.grey("\t\tPushing Offset Class: ") + chalk.white(className));
-
-                classNames.push(className);
-                return;
-              }
-
-              throw new Error("Flexi#attribute-conversion:: '" + int +
-                "' is not a valid column value for " + breakpoint.prefix + ".");
-            }
-
-            /*
-              Convert Responders
-             */
-            if (_dsl.responders.indexOf(v) !== -1) {
-              className = _dsl.generateResponderClass(breakpoint, v);
-              debug(chalk.grey("\t\tPushing Responsive Class: ") + chalk.white(className));
-
-              classNames.push(className);
-              return;
-            }
-
-            /*
-              Convert Offsets
-             */
-            if (v.indexOf('offset-') === 0) {
-              int = parseInt(v.substr(7), 10);
-
-              if (!isNaN(int)) {
-                if (int >= 0 && int < _plugin.flexiConfig.columns) {
-                  className = _dsl.generateOffsetClass(breakpoint, int, _plugin.flexiConfig.columnPrefix, _plugin.flexiConfig.columns);
-                  debug(chalk.grey("\t\tPushing Offset Class: ") + chalk.white(className));
-
-                  classNames.push(className);
-                  return;
-                }
-
-                throw new Error("Flexi#attribute-conversion:: '" + int +
-                  "' is not a valid column offset for " + breakpoint.prefix + ".");
-              }
-            }
-
-            throw new Error("Flexi#attribute-conversion:: '" + v + "' is not a valid responder value for a breakpoint.");
-          });
-
-          // clean up the node
-          removeAttribute(node, attr);
-        }
-      });
-
-      debug(chalk.magenta("\t\tFinal Class: ") + chalk.white(classNames.join(" ")));
-
-      if (!classNames.length) {
-        return;
-      }
-
-      if (!classAttr) {
-        node.attributes.push({
-          type: "AttrNode",
-          name: "class",
-          value: { type: "TextNode", chars: classNames.join(" ") }
-        });
-
-        return;
-      }
-
-      // If the AttrNode for "class" contains a MustacheStatement, `{{somethingDynamic}}`,
-      // it will be a ConcatStatement node. In such a case, add a TextNode with our
-      // classes to the list of Nodes to be concatenated.
-      if (classAttr.value.type === "ConcatStatement") {
-        classAttr.value.parts.push({ type: "TextNode", chars: " " + classNames.join(" ") });
-      } else {
-        classAttr.value.chars = classNames.join(" ");
-      }
-    }
-  });
-
-  return ast;
-};
-
-proto.validate = function AttributeConversionSupport_validate(node) {
-  var isElement = node.type === "ElementNode";
-  // is a component we convert attributes for
-  return isElement && (this.transformAll || this.dsl.elements.indexOf(node.tag) !== -1);
-};
+  throw new Error("Flexi#attribute-conversion:: '" + offset +
+    "' is not a valid column offset for " + breakpoint.prefix + ".");
+}
 
 module.exports = AttributeConversionSupport;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,7 @@ module.exports = function(defaults) {
   defaults.snippetPaths = ['tests/dummy/snippets'];
 
   var app = new EmberAddon(defaults, {
-     babel: {
+     'ember-cli-babel': {
       includePolyfill: true
     },
     hinting: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@html-next/flexi-config@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.npmjs.org/@html-next/flexi-config/-/flexi-config-2.0.0-beta.6.tgz#bdf5513e3446ad86d53fd5c087c2c61097cfd42e"
+"@html-next/flexi-config@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@html-next/flexi-config/-/flexi-config-2.0.0-beta.11.tgz#85e6eac5839b86ed405eb7ad2a0896c836e7ea5f"
   dependencies:
     ember-cli-babel "^5.1.7"
 


### PR DESCRIPTION
1. Adds comments explaining what things do
2. Removes deep conditional nesting in favor of early returns (less context == more better)
3. Pulls out a few logical block into their own methods (better encapsulation)
4. A few bike shedding changes, like newlines before control flow statements and alphabetized variables.